### PR TITLE
ci(pre-commit): freeze eslint dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,14 +48,15 @@ repos:
     rev: v8.53.0
     hooks:
       - id: eslint
+        args: [--fix]
         files: \.ts$
         types: [file]
         additional_dependencies:
-          - "@typescript-eslint/eslint-plugin"
-          - "@typescript-eslint/parser"
-          - eslint-config-prettier
-          - eslint-plugin-import
-          - eslint
-          - typescript
+          - "@typescript-eslint/eslint-plugin@6.9.1"
+          - "@typescript-eslint/parser@6.9.1"
+          - eslint@8.53.0
+          - eslint-config-prettier@9.0.0
+          - eslint-plugin-import@2.29.0
+          - typescript@5.2.2
 
 exclude: .svg|dist/


### PR DESCRIPTION
Prevent errors from the breaking change of ESLint v9.

![image](https://github.com/kenji-miyake/setup-git-cliff/assets/31987104/d2ca709d-10fe-41ba-885e-f0f6c4bc3bdd)
